### PR TITLE
Add CLI autoupdate function for n98-magerun2

### DIFF
--- a/bin/n98-magerun2
+++ b/bin/n98-magerun2
@@ -1,11 +1,23 @@
 #!/bin/bash
+
+if [ "$@" = "autoupdate" ]; then
+  echo "Downloading n98-magerun2.phar, just a moment..."
+  bin/clinotty curl -sS -O https://files.magerun.net/n98-magerun2.phar
+  bin/clinotty curl -sS -o n98-magerun2.phar.sha256 https://files.magerun.net/sha256.php?file=n98-magerun2.phar
+  bin/clinotty shasum -a 256 -c n98-magerun2.phar.sha256
+  [ $? != 0 ] && echo "sha256 checksum do not match!" && exit
+  bin/cliq chmod +x n98-magerun2.phar
+  bin/cliq mv n98-magerun2.phar bin
+  echo "n98-magerun2.phar has been updated successfully."
+  exit
+fi
+
 if ! bin/cliq ls bin/n98-magerun2.phar; then
   echo "Downloading n98-magerun2.phar, just a moment..."
   bin/clinotty curl -sS -O https://files.magerun.net/n98-magerun2.phar
   bin/clinotty curl -sS -o n98-magerun2.phar.sha256 https://files.magerun.net/sha256.php?file=n98-magerun2.phar
   bin/clinotty shasum -a 256 -c n98-magerun2.phar.sha256
   [ $? != 0 ] && echo "sha256 checksum do not match!" && exit
-
   bin/cliq chmod +x n98-magerun2.phar
   bin/cliq mkdir -p bin
   bin/cliq mv n98-magerun2.phar bin


### PR DESCRIPTION
This PR adds a new autoupdate feature to the n98-magerun2 download script. Users can now run the command "autoupdate" to download and update the n98-magerun2.phar file. The updated file is moved to the bin folder and the user is informed that the update was successful.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
